### PR TITLE
Fix resume alignment in tablet viewfix: center resume page in tablet view

### DIFF
--- a/src/pages/resume/Resume.css
+++ b/src/pages/resume/Resume.css
@@ -7,10 +7,15 @@
 {
   margin-left: 5%;
   margin-right: 5%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 .resume-page
 {
   display: block;
+  display: flex;
+  justify-content: center;
 }
 
 .resume-page > *{
@@ -37,6 +42,9 @@
 .document-resume{
   display: grid;
   place-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .single-page{

--- a/src/pages/resume/Resume.css
+++ b/src/pages/resume/Resume.css
@@ -13,7 +13,6 @@
 }
 .resume-page
 {
-  display: block;
   display: flex;
   justify-content: center;
 }


### PR DESCRIPTION
Fixed the issue where the resume section was aligned to the left in tablet view.
Added responsive CSS to center the resume content properly between 768px–1024px widths.

Resolves issue #5.
